### PR TITLE
update semantic-release to match mongo-toolchain

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,20 +1,21 @@
 ---
 jobs:
   release:
-    env:
-      GITHUB_TOKEN: '${{ secrets.GH_TOKEN }}'
+    name: release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Release
-        uses: cycjimmy/semantic-release-action@v2.1.3
+      - uses: actions/checkout@v2
         with:
-          branch: master
-          extra_plugins: |
-            @semantic-release/changelog
-            @semantic-release/git@8.0.0
-name: Release
+          ref: master
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: npm install -D @semantic-release/changelog@6.0.1 @semantic-release/git@10.0.1
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        name: Run automated package publishing
+        run: npx semantic-release@18
+name: release
 on:
   push:
     branches:


### PR DESCRIPTION
Applied this as a patch so it's line-for-line identical to ansible-role-mongo-toolchain